### PR TITLE
handle 'date' and 'main' lookups, expand 'env'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,8 +407,8 @@ fn substitute(input: &[u8]) -> (Vec<u8>, Option<Handler>) {
         // the expansion should leak a `main` argument.
         //
         // Report the `main` handler for the possible information disclosure risk, then assume
-        // empty string expansion in case this was just obfuscatory.
-        ("".into(), Some(Handler::Main))
+        // empty/default string expansion in case this was just obfuscatory.
+        (default.into(), Some(Handler::Main))
     } else if let Some(_) = strip_lower_ascii_prefix(value, b"date:") {
         // `${date:...}` expands a format string using the current time. There isn't a way to
         // select substrings, so month/day strings aren't useful for building an unaccepatble

--- a/tests/substitutions.rs
+++ b/tests/substitutions.rs
@@ -157,6 +157,13 @@ fn main_lookups() {
     assert!(findings.saw_jndi);
     assert!(findings.saw_main);
 
+    // `main` lookups support default value syntax.
+    let input = "hello ${j${main:foobar:-n}di:}";
+    let (result, findings) = parseu(input);
+    assert_eq!("hello jndi:", result);
+    assert!(findings.saw_jndi);
+    assert!(findings.saw_main);
+
     // NOTE: this is lossy. A real expansion would look like `${jn/path/to/javadi:}`. This is still not the
     // token we're really concerned about finding, so we're not worried about that detail.
     //


### PR DESCRIPTION
The logic for these lookups is simple and lossy, but that's acceptable
since we can at least report that these lookups will be made. For some
users it is reasonable to simply reject a log line at the presence of
`main` or `date`, regardless of later findings. For other users, it
doesn't seem possible to have a general transformation between a `main`
or `date` lookup, and a string useful to build other more concerning
lookup tokens (like `jndi` or `env`).

edit: also adjusted the `env` expansion to assume that env vars are for undefined variables (so, expand to `""`), but use a default value if one is provided - `${env:UNDEFINED:-hello}` should expand to `hello`.